### PR TITLE
Add initial steam API integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "license": "ISC",
   "dependencies": {
     "dotenv": "^16.1.3",
+    "steamapi": "^2.2.0",
     "tmi.js": "^1.8.5"
   }
 }

--- a/src/steam/helpers/games.js
+++ b/src/steam/helpers/games.js
@@ -1,0 +1,27 @@
+const { SteamWrapper } = require('../wrapper')
+
+// Create Steam API Wrapper
+const steam = new SteamWrapper(process.env.STEAM_API_KEY)
+
+async function getTenRandomLeastPlayed(user) {
+    const games = await steam.GetGames(user);
+    const noHours = games.filter(game => {
+        return game.playTime === 0 && !game.name.includes('Test')
+    })
+    const result = [];
+    for(let i=0; i<10; i++) {
+        const random = Math.floor(Math.random() * noHours.length);
+        result.push(noHours[random]);
+    }
+    return result;
+}
+
+async function getGameFromUser(user, gameName) {
+    const games = await steam.GetGames(user);
+    const results = games.filter(game => {
+        return game.name.includes(gameName);
+    })
+    return results;
+}
+
+module.exports = { getTenRandomLeastPlayed, getGameFromUser }

--- a/src/steam/helpers/games.js
+++ b/src/steam/helpers/games.js
@@ -19,7 +19,7 @@ async function getTenRandomLeastPlayed(user) {
 async function getGameFromUser(user, gameName) {
     const games = await steam.GetGames(user);
     const results = games.filter(game => {
-        return game.name.includes(gameName);
+        return game.name.toUpperCase().includes(gameName.toUpperCase());
     })
     return results;
 }

--- a/src/steam/wrapper.js
+++ b/src/steam/wrapper.js
@@ -1,0 +1,17 @@
+const SteamAPI = require('steamapi');
+
+class SteamWrapper {
+    constructor(apiKey) {
+        this._api = new SteamAPI(apiKey);
+    }
+
+    async GetSteamID(url) {
+        return await this._api.resolve(url);
+    }
+
+    async GetGames(userId) {
+        return await this._api.getUserOwnedGames(userId);
+    }
+}
+
+module.exports = { SteamWrapper };


### PR DESCRIPTION
This PR adds the npm package `steamapi` along with a wrapper for the wrapper and a `games` helper to obtain some basic Steam info for the Twitch Bot.

This info will be used to generate 10 random games with no play time along with finding if a given user owns a game related to a string provided (ie: "Mass Effect" will return all games (Mass Effect 1, Mass Effect 2, Mass Effect 3) that contain the string).